### PR TITLE
fix: update activity level query to include adjacent levels

### DIFF
--- a/src/controllers/activities.js
+++ b/src/controllers/activities.js
@@ -89,10 +89,16 @@ const activitiesController = {
 
       let activityIdsWithLevel = null;
       if (level) {
+        const levelsToQuery = [level];
+
+        if (level > 1) {
+          levelsToQuery.push(level - 1);
+        }
+
         const activityLevels = await activityLevelsRepo
           .createQueryBuilder('al')
           .leftJoin('al.level', 'level')
-          .where('level.level <= :level', { level })
+          .where('level.level IN (:...levels)', { levels: levelsToQuery })
           .select('al.activity_id', 'activityId')
           .groupBy('al.activity_id')
           .getRawMany();


### PR DESCRIPTION
- 更新活動程度查詢規則，顯示同程度與前一階程度，讓查詢結果程度範圍不會太大